### PR TITLE
Update formats of DATS for harmonization

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -68,7 +68,7 @@
 	"distributions": [
 		{
 			"formats": [
-				".VCF",
+				"VCF",
 				"FASTA"
             ],
 			"size" : 16.2,
@@ -121,7 +121,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 1.19,
 			        "unit" : {
@@ -239,7 +239,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 755,
 			        "unit" : {
@@ -357,7 +357,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 749,
 			        "unit" : {
@@ -475,7 +475,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 723,
 			        "unit" : {
@@ -593,7 +593,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 543,
 			        "unit" : {
@@ -711,7 +711,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 494,
 			        "unit" : {
@@ -829,7 +829,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 447,
 			        "unit" : {
@@ -947,7 +947,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 483,
 			        "unit" : {
@@ -1065,7 +1065,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 424,
 			        "unit" : {
@@ -1183,7 +1183,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 426,
 			        "unit" : {
@@ -1301,7 +1301,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 351,
 			        "unit" : {
@@ -1419,7 +1419,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 1.28,
 			        "unit" : {
@@ -1537,7 +1537,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 334,
 			        "unit" : {
@@ -1655,7 +1655,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 213,
 			        "unit" : {
@@ -1773,7 +1773,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 209,
 			        "unit" : {
@@ -1891,7 +1891,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 1.08,
 			        "unit" : {
@@ -2009,7 +2009,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 1.09,
 			        "unit" : {
@@ -2127,7 +2127,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 966,
 			        "unit" : {
@@ -2245,7 +2245,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 976,
 			        "unit" : {
@@ -2363,7 +2363,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 886,
 			        "unit" : {
@@ -2481,7 +2481,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 841,
 			        "unit" : {
@@ -2599,7 +2599,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 657,
 			        "unit" : {
@@ -2717,7 +2717,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 202,
 			        "unit" : {
@@ -2835,7 +2835,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 1.87,
 			        "unit" : {
@@ -2953,7 +2953,7 @@
 		  	"distributions": [
 	    	    {
 					"formats": [
-						".VCF"
+						"VCF"
         	   		],
 					"size" : 5.73,
 			        "unit" : {


### PR DESCRIPTION
This is step one of the DATS harmonization process happening for CONP-PCNO/conp-dataset#454.

.VCF has been replaced by VCF in the DATS file.
