### PR TITLE
Mitochondria link update

### DIFF
--- a/1KGP_chrMT.vcf.gz
+++ b/1KGP_chrMT.vcf.gz
@@ -1,1 +1,0 @@
-.git/annex/objects/vw/5x/MD5E-s206142--bcec4336e09a4f65c7161bcbe32884a9.vcf.gz/MD5E-s206142--bcec4336e09a4f65c7161bcbe32884a9.vcf.gz

--- a/1KGP_chrMT.vcf.gz
+++ b/1KGP_chrMT.vcf.gz
@@ -1,0 +1,1 @@
+.git/annex/objects/vw/5x/MD5E-s206142--bcec4336e09a4f65c7161bcbe32884a9.vcf.gz/MD5E-s206142--bcec4336e09a4f65c7161bcbe32884a9.vcf.gz


### PR DESCRIPTION
This PR updates `1KGP_chrMT.vcf.gz` to the most recent version at the source.